### PR TITLE
refactor/garter object many

### DIFF
--- a/src/Garter_Object.re
+++ b/src/Garter_Object.re
@@ -9,8 +9,6 @@ let any = a => Any(a);
 let any2 = (a, b) => [|Any(a), Any(b)|];
 let any3 = (a, b, c) => [|Any(a), Any(b), Any(c)|];
 let any4 = (a, b, c, d) => [|Any(a), Any(b), Any(c), Any(d)|];
-let anyMany = objs => {
-  Belt.Array.map(objs, x => Any(x));
-};
+let any5 = (a, b, c, d, e) => [|Any(a), Any(b), Any(c), Any(d), Any(e)|];
 
 let isEmpty = o => o->Js.Obj.keys->Garter_Array.isEmpty;

--- a/src/Garter_Object.re
+++ b/src/Garter_Object.re
@@ -10,5 +10,7 @@ let any2 = (a, b) => [|Any(a), Any(b)|];
 let any3 = (a, b, c) => [|Any(a), Any(b), Any(c)|];
 let any4 = (a, b, c, d) => [|Any(a), Any(b), Any(c), Any(d)|];
 let any5 = (a, b, c, d, e) => [|Any(a), Any(b), Any(c), Any(d), Any(e)|];
+let any6 = (a, b, c, d, e, f) => [|Any(a), Any(b), Any(c), Any(d), Any(e), Any(f)|];
+let any7 = (a, b, c, d, e, f, g) => [|Any(a), Any(b), Any(c), Any(d), Any(e), Any(f), Any(g)|];
 
 let isEmpty = o => o->Js.Obj.keys->Garter_Array.isEmpty;


### PR DESCRIPTION
Garter.Object.anyMany가 의도대로 동작하는지 의문이 듭니다.
원래 Garter.Object는 서로 모양이 다른 객체들을 한 Array에 넣기 위해 만들어진 모듈인데요, anyMany의 obj를 보면 타입이 서로 다르게 생긴 객체들의 배열이어야 할 것 같습니다. (그래야 Belt.Array.map 으로 맵핑이 가능)

이 맥락에서 보면 anyMany의 파라미터로 들어가는 objs는 함수가 풀어야하는 문제 상황을 이미 해결한(!) 상태로 들어가야 해서요. 의도대로 동작하지 않고 있습니다. 일단 필요한대로 any5를 만들어보았습니다!