### PR TITLE
Belt.Array 기본 함수 추가

### DIFF
--- a/src/Garter_Array.mjs
+++ b/src/Garter_Array.mjs
@@ -316,6 +316,74 @@ function takeWhile$1(nxs, n) {
   return takeWhileU(nxs, Curry.__1(n));
 }
 
+var drop$1 = drop;
+
+var dropWhileU$1 = dropWhileU;
+
+function dropWhile$1(nxs, pred) {
+  return dropWhileU(nxs, Curry.__1(pred));
+}
+
+var updateUnsafeU$1 = updateUnsafeU;
+
+var updateUnsafe$1 = updateUnsafe;
+
+var updateExnU$1 = updateExnU;
+
+var updateExn$1 = updateExn;
+
+function keepSome$1(nxs) {
+  return Belt_Array.keepMap(nxs, (function (x) {
+                return x;
+              }));
+}
+
+var groupBy$3 = groupBy;
+
+var indexBy$3 = indexBy;
+
+var frequencies$1 = frequencies;
+
+function distinct$1(nxs, id) {
+  return fromArrayExn(distinct(nxs, id));
+}
+
+function scan$1(nxs, init, f) {
+  return fromArrayExn(scan(nxs, init, f));
+}
+
+function chunk$1(nxs, step) {
+  return fromArrayExn(chunk(nxs, step));
+}
+
+function randomOne$1(nxs) {
+  return nxs[Js_math.random_int(0, nxs.length)];
+}
+
+var randomSample$1 = randomSample;
+
+function intersperse$1(nxs, delim) {
+  return fromArrayExn(intersperse(nxs, delim));
+}
+
+var groupBy$4 = groupBy$1;
+
+var indexBy$4 = indexBy$1;
+
+var Int$1 = {
+  groupBy: groupBy$4,
+  indexBy: indexBy$4
+};
+
+var groupBy$5 = groupBy$2;
+
+var indexBy$5 = indexBy$2;
+
+var $$String$1 = {
+  groupBy: groupBy$5,
+  indexBy: indexBy$5
+};
+
 var get = Belt_Array.get;
 
 var getExn = Belt_Array.getExn;
@@ -456,7 +524,101 @@ function NonEmpty_length(prim) {
   return prim.length;
 }
 
+function NonEmpty_size(prim) {
+  return prim.length;
+}
+
+function NonEmpty_getUnsafe(prim0, prim1) {
+  return prim0[prim1];
+}
+
+function NonEmpty_getUndefined(prim0, prim1) {
+  return prim0[prim1];
+}
+
+function NonEmpty_setUnsafe(prim0, prim1, prim2) {
+  prim0[prim1] = prim2;
+  
+}
+
+function NonEmpty_copy(prim) {
+  return prim.slice(0);
+}
+
+function NonEmpty_truncateToLengthUnsafe(prim0, prim1) {
+  prim0.length = prim1;
+  
+}
+
 var NonEmpty = {
+  length: NonEmpty_length,
+  size: NonEmpty_size,
+  get: Belt_Array.get,
+  getExn: Belt_Array.getExn,
+  getUnsafe: NonEmpty_getUnsafe,
+  getUndefined: NonEmpty_getUndefined,
+  set: Belt_Array.set,
+  setExn: Belt_Array.setExn,
+  setUnsafe: NonEmpty_setUnsafe,
+  shuffleInPlace: Belt_Array.shuffleInPlace,
+  shuffle: Belt_Array.shuffle,
+  reverseInPlace: Belt_Array.reverseInPlace,
+  reverse: Belt_Array.reverse,
+  zip: Belt_Array.zip,
+  zipByU: Belt_Array.zipByU,
+  zipBy: Belt_Array.zipBy,
+  unzip: Belt_Array.unzip,
+  concat: Belt_Array.concat,
+  concatMany: Belt_Array.concatMany,
+  slice: Belt_Array.slice,
+  sliceToEnd: Belt_Array.sliceToEnd,
+  copy: NonEmpty_copy,
+  fill: Belt_Array.fill,
+  blit: Belt_Array.blit,
+  blitUnsafe: Belt_Array.blitUnsafe,
+  forEachU: Belt_Array.forEachU,
+  forEach: Belt_Array.forEach,
+  mapU: Belt_Array.mapU,
+  map: Belt_Array.map,
+  getByU: Belt_Array.getByU,
+  getBy: Belt_Array.getBy,
+  getIndexByU: Belt_Array.getIndexByU,
+  getIndexBy: Belt_Array.getIndexBy,
+  keepU: Belt_Array.keepU,
+  keep: Belt_Array.keep,
+  keepWithIndexU: Belt_Array.keepWithIndexU,
+  keepWithIndex: Belt_Array.keepWithIndex,
+  keepMapU: Belt_Array.keepMapU,
+  keepMap: Belt_Array.keepMap,
+  forEachWithIndexU: Belt_Array.forEachWithIndexU,
+  forEachWithIndex: Belt_Array.forEachWithIndex,
+  mapWithIndexU: Belt_Array.mapWithIndexU,
+  mapWithIndex: Belt_Array.mapWithIndex,
+  partitionU: Belt_Array.partitionU,
+  partition: Belt_Array.partition,
+  reduceU: Belt_Array.reduceU,
+  reduce: Belt_Array.reduce,
+  reduceReverseU: Belt_Array.reduceReverseU,
+  reduceReverse: Belt_Array.reduceReverse,
+  reduceReverse2U: Belt_Array.reduceReverse2U,
+  reduceReverse2: Belt_Array.reduceReverse2,
+  reduceWithIndexU: Belt_Array.reduceWithIndexU,
+  reduceWithIndex: Belt_Array.reduceWithIndex,
+  joinWithU: Belt_Array.joinWithU,
+  joinWith: Belt_Array.joinWith,
+  someU: Belt_Array.someU,
+  some: Belt_Array.some,
+  everyU: Belt_Array.everyU,
+  every: Belt_Array.every,
+  some2U: Belt_Array.some2U,
+  some2: Belt_Array.some2,
+  every2U: Belt_Array.every2U,
+  every2: Belt_Array.every2,
+  cmpU: Belt_Array.cmpU,
+  cmp: Belt_Array.cmp,
+  eqU: Belt_Array.eqU,
+  eq: Belt_Array.eq,
+  truncateToLengthUnsafe: NonEmpty_truncateToLengthUnsafe,
   fromArray: fromArray,
   fromArrayExn: fromArrayExn,
   toArray: toArray,
@@ -471,7 +633,25 @@ var NonEmpty = {
   take: take$1,
   takeWhileU: takeWhileU$1,
   takeWhile: takeWhile$1,
-  length: NonEmpty_length
+  drop: drop$1,
+  dropWhileU: dropWhileU$1,
+  dropWhile: dropWhile$1,
+  updateUnsafeU: updateUnsafeU$1,
+  updateUnsafe: updateUnsafe$1,
+  updateExnU: updateExnU$1,
+  updateExn: updateExn$1,
+  keepSome: keepSome$1,
+  groupBy: groupBy$3,
+  indexBy: indexBy$3,
+  frequencies: frequencies$1,
+  distinct: distinct$1,
+  scan: scan$1,
+  chunk: chunk$1,
+  randomOne: randomOne$1,
+  randomSample: randomSample$1,
+  intersperse: intersperse$1,
+  Int: Int$1,
+  $$String: $$String$1
 };
 
 export {

--- a/src/Garter_Array.res
+++ b/src/Garter_Array.res
@@ -219,53 +219,53 @@ module NonEmpty = {
 
   let maxBy = (xs, cmp) => maxByU(xs, (. a, b) => cmp(a, b))
 
-  let take = (nxs, n) => nxs->toArray->take(n)
+  let take = (nxs, n) => nxs->take(n)
 
-  let takeWhileU = (nxs, n) => nxs->toArray->takeWhileU(n)
+  let takeWhileU = (nxs, n) => nxs->takeWhileU(n)
 
-  let takeWhile = (nxs, n) => nxs->toArray->takeWhile(n)
+  let takeWhile = (nxs, n) => nxs->takeWhile(n)
 
-  let drop = (nxs, n) => nxs->toArray->drop(n)
+  let drop = (nxs, n) => nxs->drop(n)
 
-  let dropWhileU = (nxs, pred) => nxs->toArray->dropWhileU(pred)
+  let dropWhileU = (nxs, pred) => nxs->dropWhileU(pred)
 
-  let dropWhile = (nxs, pred) => nxs->toArray->dropWhile(pred)
+  let dropWhile = (nxs, pred) => nxs->dropWhile(pred)
 
-  let updateUnsafeU = (nxs, i, f) => nxs->toArray->updateUnsafeU(i, f)
+  let updateUnsafeU = (nxs, i, f) => nxs->updateUnsafeU(i, f)
 
-  let updateUnsafe = (nxs, i, f) => nxs->toArray->updateUnsafe(i, f)
+  let updateUnsafe = (nxs, i, f) => nxs->updateUnsafe(i, f)
 
-  let updateExnU = (nxs, i, f) => nxs->toArray->updateExnU(i, f)
+  let updateExnU = (nxs, i, f) => nxs->updateExnU(i, f)
 
-  let updateExn = (nxs, i, f) => nxs->toArray->updateExn(i, f)
+  let updateExn = (nxs, i, f) => nxs->updateExn(i, f)
 
-  let keepSome = nxs => nxs->toArray->keepSome
+  let keepSome = nxs => nxs->keepSome
 
-  let groupBy = (nxs, keyFn, ~id) => nxs->toArray->groupBy(keyFn, ~id)
+  let groupBy = (nxs, keyFn, ~id) => nxs->groupBy(keyFn, ~id)
 
-  let indexBy = (nxs, indexFn, ~id) => nxs->toArray->indexBy(indexFn, ~id)
+  let indexBy = (nxs, indexFn, ~id) => nxs->indexBy(indexFn, ~id)
 
-  let frequencies = (nxs, ~id) => nxs->toArray->frequencies(~id)
+  let frequencies = (nxs, ~id) => nxs->frequencies(~id)
 
-  let distinct = (nxs, ~id) => nxs->toArray->distinct(~id)->fromArrayExn
+  let distinct = (nxs, ~id) => nxs->distinct(~id)->fromArrayExn
 
-  let scan = (nxs, init, f) => nxs->toArray->scan(init, f)->fromArrayExn
+  let scan = (nxs, init, f) => nxs->scan(init, f)->fromArrayExn
 
-  let chunk = (nxs, step) => nxs->toArray->chunk(step)->fromArrayExn
+  let chunk = (nxs, step) => nxs->chunk(step)->fromArrayExn
 
-  let randomOne = nxs => nxs->toArray->getUnsafe(Js.Math.random_int(0, length(nxs->toArray)))
+  let randomOne = nxs => nxs->getUnsafe(Js.Math.random_int(0, length(nxs)))
 
-  let randomSample = (nxs, prob) => nxs->toArray->randomSample(prob)
+  let randomSample = (nxs, prob) => nxs->randomSample(prob)
 
-  let intersperse = (nxs, delim) => nxs->toArray->intersperse(delim)->fromArrayExn
+  let intersperse = (nxs, delim) => nxs->intersperse(delim)->fromArrayExn
 
   module Int = {
-    let groupBy = (nxs, keyFn) => nxs->toArray->Int.groupBy(keyFn)
-    let indexBy = (nxs, indexFn) => nxs->toArray->Int.indexBy(indexFn)
+    let groupBy = (nxs, keyFn) => nxs->Int.groupBy(keyFn)
+    let indexBy = (nxs, indexFn) => nxs->Int.indexBy(indexFn)
   }
 
   module String = {
-    let groupBy = (nxs, keyFn) => nxs->toArray->String.groupBy(keyFn)
-    let indexBy = (nxs, indexFn) => nxs->toArray->String.indexBy(indexFn)
+    let groupBy = (nxs, keyFn) => nxs->String.groupBy(keyFn)
+    let indexBy = (nxs, indexFn) => nxs->String.indexBy(indexFn)
   }
 }

--- a/src/Garter_Array.res
+++ b/src/Garter_Array.res
@@ -179,6 +179,8 @@ module String = {
 }
 
 module NonEmpty = {
+  include Belt.Array
+
   type t<'a> = array<'a>
 
   let fromArray = xs =>
@@ -223,5 +225,47 @@ module NonEmpty = {
 
   let takeWhile = (nxs, n) => nxs->toArray->takeWhile(n)
 
-  include Belt_Array
+  let drop = (nxs, n) => nxs->toArray->drop(n)
+
+  let dropWhileU = (nxs, pred) => nxs->toArray->dropWhileU(pred)
+
+  let dropWhile = (nxs, pred) => nxs->toArray->dropWhile(pred)
+
+  let updateUnsafeU = (nxs, i, f) => nxs->toArray->updateUnsafeU(i, f)
+
+  let updateUnsafe = (nxs, i, f) => nxs->toArray->updateUnsafe(i, f)
+
+  let updateExnU = (nxs, i, f) => nxs->toArray->updateExnU(i, f)
+
+  let updateExn = (nxs, i, f) => nxs->toArray->updateExn(i, f)
+
+  let keepSome = nxs => nxs->toArray->keepSome
+
+  let groupBy = (nxs, keyFn, ~id) => nxs->toArray->groupBy(keyFn, ~id)
+
+  let indexBy = (nxs, indexFn, ~id) => nxs->toArray->indexBy(indexFn, ~id)
+
+  let frequencies = (nxs, ~id) => nxs->toArray->frequencies(~id)
+
+  let distinct = (nxs, ~id) => nxs->toArray->distinct(~id)->fromArrayExn
+
+  let scan = (nxs, init, f) => nxs->toArray->scan(init, f)->fromArrayExn
+
+  let chunk = (nxs, step) => nxs->toArray->chunk(step)->fromArrayExn
+
+  let randomOne = nxs => nxs->toArray->getUnsafe(Js.Math.random_int(0, length(nxs->toArray)))
+
+  let randomSample = (nxs, prob) => nxs->toArray->randomSample(prob)
+
+  let intersperse = (nxs, delim) => nxs->toArray->intersperse(delim)->fromArrayExn
+
+  module Int = {
+    let groupBy = (nxs, keyFn) => nxs->toArray->Int.groupBy(keyFn)
+    let indexBy = (nxs, indexFn) => nxs->toArray->Int.indexBy(indexFn)
+  }
+
+  module String = {
+    let groupBy = (nxs, keyFn) => nxs->toArray->String.groupBy(keyFn)
+    let indexBy = (nxs, indexFn) => nxs->toArray->String.indexBy(indexFn)
+  }
 }

--- a/src/Garter_Array.resi
+++ b/src/Garter_Array.resi
@@ -138,6 +138,114 @@ module String: {
 module NonEmpty: {
   type t<'a>
 
+  let length: t<'a> => int
+
+  let size: t<'a> => int
+
+  let get: (t<'a>, int) => option<'a>
+  let getExn: (t<'a>, int) => 'a
+  let getUnsafe: (t<'a>, int) => 'a
+  let getUndefined: (t<'a>, int) => Js.Undefined.t<'a>
+
+  let set: (t<'a>, int, 'a) => bool
+  let setExn: (t<'a>, int, 'a) => unit
+  let setUnsafe: (t<'a>, int, 'a) => unit
+
+  let shuffleInPlace: t<'a> => unit
+  let shuffle: t<'a> => t<'a>
+
+  let reverseInPlace: t<'a> => unit
+  let reverse: t<'a> => t<'a>
+
+  let zip: (t<'a>, t<'b>) => t<('a, 'b)>
+  let zipByU: (t<'a>, t<'b>, (. 'a, 'b) => 'c) => t<'c>
+  let zipBy: (t<'a>, t<'b>, ('a, 'b) => 'c) => t<'c>
+
+  let unzip: t<('a, 'b)> => (t<'a>, t<'b>)
+
+  let concat: (t<'a>, t<'a>) => t<'a>
+  let concatMany: t<array<'a>> => array<'a>
+
+  let slice: (t<'a>, ~offset: int, ~len: int) => array<'a>
+  let sliceToEnd: (t<'a>, int) => array<'a>
+  let copy: t<'a> => t<'a>
+
+  let fill: (t<'a>, ~offset: int, ~len: int, 'a) => unit
+
+  let blit: (~src: t<'a>, ~srcOffset: int, ~dst: array<'a>, ~dstOffset: int, ~len: int) => unit
+  let blitUnsafe: (
+    ~src: t<'a>,
+    ~srcOffset: int,
+    ~dst: array<'a>,
+    ~dstOffset: int,
+    ~len: int,
+  ) => unit
+
+  let forEachU: (t<'a>, (. 'a) => unit) => unit
+  let forEach: (t<'a>, 'a => unit) => unit
+
+  let mapU: (t<'a>, (. 'a) => 'b) => t<'b>
+  let map: (t<'a>, 'a => 'b) => t<'b>
+
+  let getByU: (t<'a>, (. 'a) => bool) => option<'a>
+  let getBy: (t<'a>, 'a => bool) => option<'a>
+
+  let getIndexByU: (t<'a>, (. 'a) => bool) => option<int>
+  let getIndexBy: (t<'a>, 'a => bool) => option<int>
+
+  let keepU: (t<'a>, (. 'a) => bool) => array<'a>
+  let keep: (t<'a>, 'a => bool) => array<'a>
+
+  let keepWithIndexU: (t<'a>, (. 'a, int) => bool) => array<'a>
+  let keepWithIndex: (t<'a>, ('a, int) => bool) => array<'a>
+
+  let keepMapU: (t<'a>, (. 'a) => option<'b>) => array<'b>
+  let keepMap: (t<'a>, 'a => option<'b>) => array<'b>
+
+  let forEachWithIndexU: (t<'a>, (. int, 'a) => unit) => unit
+  let forEachWithIndex: (t<'a>, (int, 'a) => unit) => unit
+
+  let mapWithIndexU: (t<'a>, (. int, 'a) => 'b) => t<'b>
+  let mapWithIndex: (t<'a>, (int, 'a) => 'b) => t<'b>
+
+  let partitionU: (t<'a>, (. 'a) => bool) => (array<'a>, array<'a>)
+  let partition: (t<'a>, 'a => bool) => (array<'a>, array<'a>)
+
+  let reduceU: (t<'b>, 'a, (. 'a, 'b) => 'a) => 'a
+  let reduce: (t<'b>, 'a, ('a, 'b) => 'a) => 'a
+
+  let reduceReverseU: (t<'b>, 'a, (. 'a, 'b) => 'a) => 'a
+  let reduceReverse: (t<'b>, 'a, ('a, 'b) => 'a) => 'a
+
+  let reduceReverse2U: (t<'a>, t<'b>, 'c, (. 'c, 'a, 'b) => 'c) => 'c
+  let reduceReverse2: (t<'a>, t<'b>, 'c, ('c, 'a, 'b) => 'c) => 'c
+
+  let reduceWithIndexU: (t<'a>, 'b, (. 'b, 'a, int) => 'b) => 'b
+  let reduceWithIndex: (t<'a>, 'b, ('b, 'a, int) => 'b) => 'b
+
+  let joinWithU: (t<'a>, string, (. 'a) => string) => string
+  let joinWith: (t<'a>, string, 'a => string) => string
+
+  let someU: (t<'a>, (. 'a) => bool) => bool
+  let some: (t<'a>, 'a => bool) => bool
+
+  let everyU: (t<'a>, (. 'a) => bool) => bool
+  let every: (t<'a>, 'a => bool) => bool
+
+  let some2U: (t<'a>, t<'b>, (. 'a, 'b) => bool) => bool
+  let some2: (t<'a>, t<'b>, ('a, 'b) => bool) => bool
+
+  let every2U: (t<'a>, t<'b>, (. 'a, 'b) => bool) => bool
+  let every2: (t<'a>, t<'b>, ('a, 'b) => bool) => bool
+
+  let cmpU: (t<'a>, t<'a>, (. 'a, 'a) => int) => int
+  let cmp: (t<'a>, t<'a>, ('a, 'a) => int) => int
+
+  let eqU: (t<'a>, t<'a>, (. 'a, 'a) => bool) => bool
+  let eq: (t<'a>, t<'a>, ('a, 'a) => bool) => bool
+
+  let truncateToLengthUnsafe: (t<'a>, int) => unit
+
   let fromArray: array<'a> => option<t<'a>>
   let fromArrayExn: array<'a> => t<'a>
 
@@ -159,5 +267,42 @@ module NonEmpty: {
   let takeWhileU: (t<'a>, (. 'a) => bool) => array<'a>
   let takeWhile: (t<'a>, 'a => bool) => array<'a>
 
-  let length: t<'a> => int
+  let drop: (t<'a>, int) => array<'a>
+  let dropWhileU: (t<'a>, (. 'a) => bool) => array<'a>
+  let dropWhile: (t<'a>, 'a => bool) => array<'a>
+
+  let updateUnsafeU: (t<'a>, int, (. 'a) => 'a) => unit
+  let updateUnsafe: (t<'a>, int, 'a => 'a) => unit
+  let updateExnU: (t<'a>, int, (. 'a) => 'a) => unit
+  let updateExn: (t<'a>, int, 'a => 'a) => unit
+
+  let keepSome: t<option<'a>> => array<'a>
+
+  let groupBy: (t<'a>, 'a => 'b, ~id: Belt.Map.id<'b, 'c>) => Belt.Map.t<'b, t<'a>, 'c>
+
+  let indexBy: (t<'a>, 'a => 'b, ~id: Belt.Map.id<'b, 'c>) => Belt.Map.t<'b, 'a, 'c>
+
+  let frequencies: (t<'a>, ~id: Belt.Map.id<'a, 'b>) => Belt.Map.t<'a, int, 'b>
+
+  let distinct: (t<'a>, ~id: Belt.Set.id<'a, 'b>) => t<'a>
+
+  let scan: (t<'a>, 'b, ('b, 'a) => 'b) => t<'b>
+
+  let chunk: (t<'a>, int) => t<array<'a>>
+
+  let randomOne: t<'a> => 'a
+
+  let randomSample: (t<'a>, float) => array<'a>
+
+  let intersperse: (t<'a>, 'a) => t<'a>
+
+  module Int: {
+    let groupBy: (t<'a>, 'a => Belt.Map.Int.key) => Belt.Map.Int.t<t<'a>>
+    let indexBy: (t<'a>, 'a => Belt.Map.Int.key) => Belt.Map.Int.t<'a>
+  }
+
+  module String: {
+    let groupBy: (t<'a>, 'a => Belt.Map.String.key) => Belt.Map.String.t<t<'a>>
+    let indexBy: (t<'a>, 'a => Belt.Map.String.key) => Belt.Map.String.t<'a>
+  }
 }


### PR DESCRIPTION
* 기본함수 인터페이스를 상단에, Garter.Array의 함수 인터페이스를 하단으로 순서를 구성했습니다.
* slice, keep, partition 등과 같은 함수는 반환 값이 NonEmpty를 보장하지 않기 때문에 반환 타입을 array<'a>로 표현하였습니다.