### PR TITLE
RFC: Object.toJsonUnsafe, Array.String.joinWith 추가

### DIFF
--- a/src/Garter_Array.mjs
+++ b/src/Garter_Array.mjs
@@ -217,6 +217,12 @@ var Int = {
   indexBy: indexBy$1
 };
 
+function joinWith(xs, s) {
+  return Belt_Array.joinWithU(xs, s, (function (x) {
+                return x;
+              }));
+}
+
 function groupBy$2(xs, keyFn) {
   return Belt_Array.reduceU(xs, undefined, (function (res, x) {
                 return Belt_MapString.updateU(res, Curry._1(keyFn, x), (function (v) {
@@ -236,6 +242,7 @@ function indexBy$2(xs, indexFn) {
 }
 
 var $$String = {
+  joinWith: joinWith,
   groupBy: groupBy$2,
   indexBy: indexBy$2
 };
@@ -379,11 +386,6 @@ var groupBy$5 = groupBy$2;
 
 var indexBy$5 = indexBy$2;
 
-var $$String$1 = {
-  groupBy: groupBy$5,
-  indexBy: indexBy$5
-};
-
 var get = Belt_Array.get;
 
 var getExn = Belt_Array.getExn;
@@ -494,7 +496,7 @@ var reduceWithIndex = Belt_Array.reduceWithIndex;
 
 var joinWithU = Belt_Array.joinWithU;
 
-var joinWith = Belt_Array.joinWith;
+var joinWith$1 = Belt_Array.joinWith;
 
 var someU = Belt_Array.someU;
 
@@ -549,6 +551,12 @@ function NonEmpty_truncateToLengthUnsafe(prim0, prim1) {
   prim0.length = prim1;
   
 }
+
+var NonEmpty_String = {
+  joinWith: joinWith,
+  groupBy: groupBy$5,
+  indexBy: indexBy$5
+};
 
 var NonEmpty = {
   length: NonEmpty_length,
@@ -651,7 +659,7 @@ var NonEmpty = {
   randomSample: randomSample$1,
   intersperse: intersperse$1,
   Int: Int$1,
-  $$String: $$String$1
+  $$String: NonEmpty_String
 };
 
 export {
@@ -710,7 +718,7 @@ export {
   reduceWithIndexU ,
   reduceWithIndex ,
   joinWithU ,
-  joinWith ,
+  joinWith$1 as joinWith,
   someU ,
   some ,
   everyU ,

--- a/src/Garter_Array.res
+++ b/src/Garter_Array.res
@@ -157,6 +157,10 @@ module Int = {
 }
 
 module String = {
+  let joinWith = (xs, s) => {
+    Belt.Array.joinWithU(xs, s, (. x) => x)
+  }
+
   // Belt.Map 대신 Belt.Map.String을 씁니다.
   let groupBy = (xs, keyFn) => {
     let empty = Belt.Map.String.empty
@@ -267,5 +271,6 @@ module NonEmpty = {
   module String = {
     let groupBy = (nxs, keyFn) => nxs->String.groupBy(keyFn)
     let indexBy = (nxs, indexFn) => nxs->String.indexBy(indexFn)
+    let joinWith = String.joinWith
   }
 }

--- a/src/Garter_Array.resi
+++ b/src/Garter_Array.resi
@@ -131,6 +131,7 @@ module Int: {
 }
 
 module String: {
+  let joinWith: (array<string>, string) => string
   let groupBy: (array<'a>, 'a => Belt.Map.String.key) => Belt.Map.String.t<array<'a>>
   let indexBy: (array<'a>, 'a => Belt.Map.String.key) => Belt.Map.String.t<'a>
 }
@@ -302,6 +303,7 @@ module NonEmpty: {
   }
 
   module String: {
+    let joinWith: (t<string>, string) => string
     let groupBy: (t<'a>, 'a => Belt.Map.String.key) => Belt.Map.String.t<t<'a>>
     let indexBy: (t<'a>, 'a => Belt.Map.String.key) => Belt.Map.String.t<'a>
   }

--- a/src/Garter_Object.mjs
+++ b/src/Garter_Object.mjs
@@ -69,6 +69,10 @@ function isEmpty(o) {
   return Garter_Array.isEmpty(Object.keys(o));
 }
 
+function toJson(prim) {
+  return prim;
+}
+
 export {
   fromKV ,
   any ,
@@ -79,6 +83,7 @@ export {
   any6 ,
   any7 ,
   isEmpty ,
+  toJson ,
   
 }
 /* No side effect */

--- a/src/Garter_Object.mjs
+++ b/src/Garter_Object.mjs
@@ -69,7 +69,7 @@ function isEmpty(o) {
   return Garter_Array.isEmpty(Object.keys(o));
 }
 
-function toJson(prim) {
+function toJsonUnsafe(prim) {
   return prim;
 }
 
@@ -83,7 +83,7 @@ export {
   any6 ,
   any7 ,
   isEmpty ,
-  toJson ,
+  toJsonUnsafe ,
   
 }
 /* No side effect */

--- a/src/Garter_Object.res
+++ b/src/Garter_Object.res
@@ -13,4 +13,4 @@ let any7 = (a, b, c, d, e, f, g) => [Any(a), Any(b), Any(c), Any(d), Any(e), Any
 
 let isEmpty = o => o->Js.Obj.keys->Garter_Array.isEmpty
 
-external toJson: {..} => Js.Json.t = "%identity"
+external toJsonUnsafe: {..} => Js.Json.t = "%identity"

--- a/src/Garter_Object.res
+++ b/src/Garter_Object.res
@@ -12,3 +12,5 @@ let any6 = (a, b, c, d, e, f) => [Any(a), Any(b), Any(c), Any(d), Any(e), Any(f)
 let any7 = (a, b, c, d, e, f, g) => [Any(a), Any(b), Any(c), Any(d), Any(e), Any(f), Any(g)]
 
 let isEmpty = o => o->Js.Obj.keys->Garter_Array.isEmpty
+
+external toJson: {..} => Js.Json.t = "%identity"

--- a/src/Garter_Object.resi
+++ b/src/Garter_Object.resi
@@ -18,3 +18,5 @@ let any5: ({..}, {..}, {..}, {..}, {..}) => array<t>
 let any6: ({..}, {..}, {..}, {..}, {..}, {..}) => array<t>
 let any7: ({..}, {..}, {..}, {..}, {..}, {..}, {..}) => array<t>
 let isEmpty: {..} => bool
+
+let toJson: {..} => Js.Json.t

--- a/src/Garter_Object.resi
+++ b/src/Garter_Object.resi
@@ -19,4 +19,4 @@ let any6: ({..}, {..}, {..}, {..}, {..}, {..}) => array<t>
 let any7: ({..}, {..}, {..}, {..}, {..}, {..}, {..}) => array<t>
 let isEmpty: {..} => bool
 
-let toJson: {..} => Js.Json.t
+let toJsonUnsafe: {..} => Js.Json.t

--- a/test/__tests__/Index.mjs
+++ b/test/__tests__/Index.mjs
@@ -6,6 +6,8 @@ import * as Object_test from "./spec/Object_test.mjs";
 import * as String_test from "./spec/String_test.mjs";
 import * as Array_NonEmpty_test from "./spec/Array_NonEmpty_test.mjs";
 
+var $$String = Array_test.$$String;
+
 var emptyArray = Array_NonEmpty_test.emptyArray;
 
 var nonEmptyArray = Array_NonEmpty_test.nonEmptyArray;
@@ -13,6 +15,7 @@ var nonEmptyArray = Array_NonEmpty_test.nonEmptyArray;
 var testEqual = String_test.testEqual;
 
 export {
+  $$String ,
   emptyArray ,
   nonEmptyArray ,
   testEqual ,

--- a/test/__tests__/Index.mjs
+++ b/test/__tests__/Index.mjs
@@ -12,12 +12,15 @@ var emptyArray = Array_NonEmpty_test.emptyArray;
 
 var nonEmptyArray = Array_NonEmpty_test.nonEmptyArray;
 
+var roundtrip = Object_test.roundtrip;
+
 var testEqual = String_test.testEqual;
 
 export {
   $$String ,
   emptyArray ,
   nonEmptyArray ,
+  roundtrip ,
   testEqual ,
   
 }

--- a/test/__tests__/spec/Array_NonEmpty_test.mjs
+++ b/test/__tests__/spec/Array_NonEmpty_test.mjs
@@ -3,7 +3,6 @@
 import * as Caml from "@rescript/std/lib/es6/caml.js";
 import * as Zora from "@dusty-phillips/rescript-zora/src/Zora.mjs";
 import * as Zora$1 from "zora";
-import * as Belt_Array from "@rescript/std/lib/es6/belt_Array.js";
 import * as Belt_Option from "@rescript/std/lib/es6/belt_Option.js";
 import * as Garter_Array from "../../../src/Garter_Array.mjs";
 
@@ -66,7 +65,7 @@ Zora$1.test("take", (function (t) {
       }));
 
 Zora$1.test("reduce1", (function (t) {
-        return testEqual(t, "", Garter_Array.NonEmpty.reduce1(Garter_Array.NonEmpty.fromArrayExn(Belt_Array.range(1, 10)), (function (prim0, prim1) {
+        return testEqual(t, "", Garter_Array.NonEmpty.reduce1(Garter_Array.NonEmpty.fromArrayExn(Garter_Array.range(1, 10)), (function (prim0, prim1) {
                           return prim0 + prim1 | 0;
                         })), 55);
       }));

--- a/test/__tests__/spec/Array_NonEmpty_test.res
+++ b/test/__tests__/spec/Array_NonEmpty_test.res
@@ -1,7 +1,7 @@
 open Zora
 
-open Belt.Array
-open Garter.Array.NonEmpty
+open Garter.Array
+open! Garter.Array.NonEmpty
 
 let testEqual = (t, name, lhs, rhs) =>
   t->test(name, t => {

--- a/test/__tests__/spec/Array_test.mjs
+++ b/test/__tests__/spec/Array_test.mjs
@@ -164,8 +164,21 @@ Zora$1.test("intersperse", (function (t) {
                   ]);
       }));
 
+Zora$1.test("joinWith", (function (t) {
+        testEqual(t, "", Garter_Array.$$String.joinWith([], ","), "");
+        testEqual(t, "", Garter_Array.$$String.joinWith(["a"], ","), "a");
+        return testEqual(t, "", Garter_Array.$$String.joinWith([
+                        "a",
+                        "b",
+                        "c"
+                      ], ","), "a,b,c");
+      }));
+
+var $$String = {};
+
 export {
   testEqual ,
+  $$String ,
   
 }
 /*  Not a pure module */

--- a/test/__tests__/spec/Array_test.res
+++ b/test/__tests__/spec/Array_test.res
@@ -40,3 +40,11 @@ zoraBlock("intersperse", t => {
   t->testEqual("3", intersperse([1, 2], 0), [1, 0, 2])
   t->testEqual("4", intersperse([1, 2, 3], 0), [1, 0, 2, 0, 3])
 })
+
+module String = {
+  zoraBlock("joinWith", t => {
+    t->testEqual("", String.joinWith([], ","), "")
+    t->testEqual("", String.joinWith(["a"], ","), "a")
+    t->testEqual("", String.joinWith(["a", "b", "c"], ","), "a,b,c")
+  })
+}

--- a/test/__tests__/spec/Object_test.mjs
+++ b/test/__tests__/spec/Object_test.mjs
@@ -2,6 +2,8 @@
 
 import * as Zora from "@dusty-phillips/rescript-zora/src/Zora.mjs";
 import * as Zora$1 from "zora";
+import * as Js_dict from "@rescript/std/lib/es6/js_dict.js";
+import * as Belt_Option from "@rescript/std/lib/es6/belt_Option.js";
 import * as Garter_Object from "../../../src/Garter_Object.mjs";
 
 function testEqual(t, name, lhs, rhs) {
@@ -18,8 +20,37 @@ Zora$1.test("fromKV", (function (t) {
                   });
       }));
 
+function roundtrip(o) {
+  return Belt_Option.map(JSON.stringify(o), (function (prim) {
+                return JSON.parse(prim);
+              }));
+}
+
+Zora$1.test("toJsonUnsafe", (function (t) {
+        t.test("safe", (function (t) {
+                t.equal(Garter_Object.toJsonUnsafe({
+                          x: 0
+                        }), Js_dict.fromArray([[
+                            "x",
+                            0.0
+                          ]]), "dict");
+                return Zora.done(undefined);
+              }));
+        t.test("unsafe", (function (t) {
+                var o = {
+                  x: (function (param) {
+                      return 1;
+                    })
+                };
+                t.notEqual(Garter_Object.toJsonUnsafe(o), roundtrip(o), "function");
+                return Zora.done(undefined);
+              }));
+        
+      }));
+
 export {
   testEqual ,
+  roundtrip ,
   
 }
 /*  Not a pure module */

--- a/test/__tests__/spec/Object_test.res
+++ b/test/__tests__/spec/Object_test.res
@@ -8,3 +8,25 @@ let testEqual = (t, name, lhs, rhs) =>
   })
 
 zoraBlock("fromKV", t => t->testEqual("1", Garter.Object.fromKV("a", 1), {"a": 1}))
+
+let roundtrip = (o: {..}) => {
+  Js.Json.stringifyAny(o)->Belt.Option.map(Js.Json.parseExn)->Belt.Option.getUnsafe
+}
+
+zoraBlock("toJsonUnsafe", t => {
+  t->test("safe", t => {
+    t->equal(
+      Garter.Object.toJsonUnsafe({"x": 0}),
+      Js.Json.object_(Js.Dict.fromArray([("x", Js.Json.number(0.0))])),
+      "dict",
+    )
+    done()
+  })
+
+  t->test("unsafe", t => {
+    let o = {"x": () => 1}
+    t->notEqual(Garter.Object.toJsonUnsafe(o), roundtrip(o), "function")
+
+    done()
+  })
+})


### PR DESCRIPTION
왜 만들었나?

#### 1. Array.String.joinWith

- Js.Array2.joinWith 는 array<'t> 에 대해 동작하기 때문에 't => string 으로 암묵적인 형변환이 일어납니다. 
- Belt.Array.joinWith 는 이를 극복하기 위해 't => string 으로의 변환 함수를 인자로 입력받지만, 대부분의 경우는 `'t == string` 이라 번거롭습니다.
   - 예: `Belt.Array.joinWith(["a", "b"], ",", x => x)    // 불필요한 x => x 가 있음`



#### 2. Object.toJsonUnsafe

Js.Json.t 로 객체를 인코딩 하는건 좀 귀찮습니다.
rescript-json나 bs-json 같은 인코더를 써도 불편합니다.

특히 코드상에서 안전한 리터럴로 표현됨이 분명한 상황에서는 더 그렇습니다.
이런 상황에서 야매로 변환을 하라고 만들었습니다.
